### PR TITLE
🏷️ fix typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,17 +3,13 @@ export namespace Evdev {
     raw?: boolean;
   };
 
-  enum EventType {
-    EV_KEY = 'EV_KEY',
-    EV_ABS = 'EV_ABS',
-    EV_SYN = 'EV_SYN',
-  }
+  type EventType = "EV_KEY" | "EV_ABS" | "EV_SYN";
 
   type Event = {
     type: EventType;
     code: string;
     value: string | number;
-    time: string;
+    time: { tv_sec: number; tv_usec: number };
   };
 
   class Device {


### PR DESCRIPTION
1. Fix typing in `Event.time`
2. Fix typing in `EventType` - enum is suitable only when it's used in typescript implementation
